### PR TITLE
Add alternative CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ yarn add micromodal
 
 **via CDN direct link**
 ```
+<script src="https://cdn.jsdelivr.net/npm/micromodal/dist/micromodal.min.js"></script>
+<!-- or -->
 <script src="https://unpkg.com/micromodal/dist/micromodal.min.js"></script>
 ```
 


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/micromodal) to your readme as an alternative to unpkg. jsDelivr is the fastest opensource CDN available and built specifically for production usage. It can serve any project from npm with zero config just like unpkg, but offers a larger network and better reliability.