### PR TITLE
Prevent open links if modal opens

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,11 +38,13 @@ const MicroModal = (() => {
 
     registerTriggers (...triggers) {
       triggers.forEach(trigger => {
-        trigger.addEventListener('click', () => this.showModal())
+        trigger.addEventListener('click', event => this.showModal(event))
       })
     }
 
-    showModal () {
+    showModal (event) {
+      if (event.target.nodeName === 'A') event.preventDefault()
+
       this.activeElement = document.activeElement
       this.modal.setAttribute('aria-hidden', 'false')
       this.scrollBehaviour('disable')


### PR DESCRIPTION
Hello,

Had to take care of users with disabled js on my website by creating separate pages with same content as in modals. So I had to prevent opening links for users with enabled js and this is how I done this.

Maybe there was other way?

Thanks for your package :)