### PR TITLE
Don't change body height when toggling disableScroll

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -104,10 +104,10 @@ const MicroModal = (() => {
       const body = document.querySelector('body')
       switch (toggle) {
         case 'enable':
-          Object.assign(body.style, { overflow: '', height: '' })
+          Object.assign(body.style, { overflow: '' })
           break
         case 'disable':
-          Object.assign(body.style, { overflow: 'hidden', height: '100vh' })
+          Object.assign(body.style, { overflow: 'hidden' })
           break
         default:
       }


### PR DESCRIPTION
If you have added a background colour to your `html` element, setting the vertical height on the `body` causes it to shrink the page and brings the `html` element's background colour into the viewport.

**With vertical height:**
![image](https://user-images.githubusercontent.com/7908386/66259360-ce921b00-e7fb-11e9-80c6-5df17331b940.png)

**Without vertical height:**
![image](https://user-images.githubusercontent.com/7908386/66259391-33e60c00-e7fc-11e9-9a0c-90d1d4859110.png)


Closes #224