### PR TITLE
Fixed exception when closing modal and the active element when opened doesn't support focus()

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -79,7 +79,7 @@ const MicroModal = (() => {
       this.modal.setAttribute('aria-hidden', 'true')
       this.removeEventListeners()
       this.scrollBehaviour('enable')
-      if (this.activeElement) {
+      if (this.activeElement && this.activeElement.focus) {
         this.activeElement.focus()
       }
       this.config.onClose(this.modal)


### PR DESCRIPTION
Added check when closing modal to make sure the targetElement actually supports `focus()`. This fixes, for example, an error in IE where SVGElement doesn't actually implement `focus()`.