### PR TITLE
Clear events in case previous modal wasn't close

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -280,6 +280,9 @@ const MicroModal = (() => {
     // Checks if modals and triggers exist in dom
     if (options.debugMode === true && validateModalPresence(targetModal) === false) return
 
+    // clear events in case previous modal wasn't close
+    if (activeModal) activeModal.removeEventListeners();
+
     // stores reference to active modal
     activeModal = new Modal(options) // eslint-disable-line no-new
     activeModal.showModal()


### PR DESCRIPTION
Events needs to be cleared in case of successive calls to show(modal_id), specially the document.keydown event