### PR TITLE
Added HTMLElement as targetModal support

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -29,8 +29,10 @@ const MicroModal = (() => {
       awaitOpenAnimation = false,
       debugMode = false
     }) {
+
       // Save a reference of the modal
-      this.modal = document.getElementById(targetModal)
+      this.modal = (typeof targetModal === string) ?
+        document.getElementById(targetModal) : targetModal;
 
       // Save a reference to the passed config
       this.config = { debugMode, disableScroll, openTrigger, closeTrigger, onShow, onClose, awaitCloseAnimation, awaitOpenAnimation, disableFocus }
@@ -85,7 +87,7 @@ const MicroModal = (() => {
       this.config.onClose(this.modal)
 
       if (this.config.awaitCloseAnimation) {
-        this.modal.addEventListener('animationend', function handler () {
+        this.modal.addEventListener('animationend', function handler() {
           modal.classList.remove('is-open')
           modal.removeEventListener('animationend', handler, false)
         }, false)
@@ -94,9 +96,16 @@ const MicroModal = (() => {
       }
     }
 
-    closeModalById (targetModal) {
-      this.modal = document.getElementById(targetModal)
+    closeModalByTarget (targetModal) {
+      this.modal = (typeof targetModal === 'string') ?
+        document.getElementById(targetModal) : targetModal;
+      
       if (this.modal) this.closeModal()
+    }
+
+    closeModalByRoot (root) {
+      this.modal = root;
+      if (this.modal) this.closeModal();
     }
 
     scrollBehaviour (toggle) {
@@ -199,12 +208,13 @@ const MicroModal = (() => {
   }
 
   /**
-   * Validates whether a modal of the given id exists
-   * in the DOM
-   * @param  {number} id  The id of the modal
+   * Validates whether a modal of the given targetModal exists
+   * @param  {number} targetModal  The id of the modal
    * @return {boolean}
    */
-  const validateModalPresence = id => {
+  const validateModalPresence = targetModal => {
+    if (targetModal instanceof Element) return;
+
     if (!document.getElementById(id)) {
       console.warn(`MicroModal: \u2757Seems like you have missed %c'${ id }'`, 'background-color: #f8f9fa;color: #50596c;font-weight: bold;', 'ID somewhere in your code. Refer example below to resolve it.')
       console.warn(`%cExample:`, 'background-color: #f8f9fa;color: #50596c;font-weight: bold;', `<div class="modal" id="${ id }"></div>`)
@@ -269,7 +279,7 @@ const MicroModal = (() => {
 
   /**
    * Shows a particular modal
-   * @param  {string} targetModal [The id of the modal to display]
+   * @param  {string|HTMLElement} targetModal [The modal to display or its id]
    * @param  {object} config [The configuration object to pass]
    * @return {void}
    */
@@ -287,11 +297,11 @@ const MicroModal = (() => {
 
   /**
    * Closes the active modal
-   * @param  {string} targetModal [The id of the modal to close]
+   * @param  {string|HTMLElement} targetModal [The modal to close or its id]
    * @return {void}
    */
   const close = targetModal => {
-    targetModal ? activeModal.closeModalById(targetModal) : activeModal.closeModal()
+    targetModal ? activeModal.closeModalByTarget(targetModal) : activeModal.closeModal()
   }
 
   return { init, show, close }


### PR DESCRIPTION
Hi.
Thanks for your modal library! 
I really like easy to use, lightweight and a11y libs.

So, to show/hide the modal we need provide its id. Honestly, it doesn't look good at the first glance, but I found it quite useful.

But in some cases this behavior is not flexible enough.

I mean, I can open modal only by it's id, but what if I already have its root element? Why do I have to get its Id? Even more: in my case I have  some modals on the page and I can't provide unique id's for them, but I have their root elements (yea, I'll just change my logic for now, but I believe that there're cases where it's not possible)

But allowing root element of the modal as targetModal (and the id of the modal too) guarantee that there're some ways always (or almost)