### PR TITLE
Add conditional to read focusableNodes

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -162,7 +162,7 @@ const MicroModal = (() => {
           event.preventDefault()
         }
 
-        if (!event.shiftKey && focusedItemIndex === focusableNodes.length - 1) {
+        if (!event.shiftKey && focusableNodes.length > 0 && focusedItemIndex === focusableNodes.length - 1) {
           focusableNodes[0].focus()
           event.preventDefault()
         }


### PR DESCRIPTION
`focusableNodes` array can be 0 and when `focusedItemIndex` is -1 it will try to access the first node with focus but it does not exist. Hence the error `Uncaught TypeError: Cannot read property 'focus' of undefined` is happening