### PR TITLE
simplify contributions by fully automating the dev setup with gitpod.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - before: yarn install && yarn global add parcel
+    command: yarn run dev
+ports:
+  - port: 1234
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
   <a href="https://travis-ci.org/ghosh/micromodal" target="_blank" rel="noopener">
     <img src="https://api.travis-ci.org/ghosh/micromodal.svg" alt="Build Status">
   </a>
+  <a href="https://gitpod.io/#https://github.com/ghosh/Micromodal">
+    <img src="https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod" alt="Gitpod Ready-to-Code">
+  </a>
 </p>
 
 <p align="center">
@@ -92,6 +95,18 @@ Find the latest changelog [here](https://github.com/ghosh/micromodal/blob/master
 We are always open and invite developers to contribute to Micromodal. We have kept the guidelines and process dead simple, so you invest more time in making modals accessible to all.
 
 Micromodal follows the [standardjs](https://standardjs.com/) coding standard and is part of our `package.json` file. It will help us to maintain consistency in the code base.
+
+#### One-click online setup
+
+You can use Gitpod (A free online VS Code-like IDE) for contributing online. With a single click it'll launch a workspace and automatically:
+
+- clone the Micromodal repo.
+- install the dependencies.
+- start `yarn run dev`.
+
+so that you can start straight away.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 #### Development setup
 1. Clone Github repo `$ git clone https://github.com/ghosh/micromodal.git`


### PR DESCRIPTION
Hi! :slightly_smiling_face:  

This Pr simplifies code contributions by fully automating the dev setup with Gitpod, a free online VS Code like IDE with a single click it'll launch a workspace and automatically:

- clone the Micromodal repo. 
- install the dependencies.
- start `yarn run dev`.

So that anyone interested in contributing can start straight away.

You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/MicroModal

This is how it looks

![image](https://user-images.githubusercontent.com/46004116/75878882-27fa8680-5e3c-11ea-8755-d7af10056e44.png)
 