### PR TITLE
Add engines property to support Parcel and browserslist

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
   "homepage": "https://github.com/ghosh/micromodal#readme",
   "dependencies": {
     "concurrently": "^5.1.0"
+  },
+  "engines": {
+    "node": ">=10"
   }
 }


### PR DESCRIPTION
Parcel cannot figure out how to handle Micromodal because there's no `engines` specified in `package.json`, so it spits it out as-is instead of transforming it according to the instructions in browserslist. This causes browsers that don't support features like arrow functions, backticks and spread to choke.

See this sample for an example of the problem: https://github.com/jmosbech/micromodal-parcel-ie11
