### PR TITLE
Fix for close

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -287,13 +287,11 @@ const MicroModal = (() => {
     if (options.debugMode === true && validateArgs(triggers, triggerMap) === false) return
 
     // For every target modal creates a new instance
-    if (triggerMap.length > 0) {
-      for (var key in triggerMap) {
-        let value = triggerMap[key]
-        options.targetModal = key
-        options.triggers = [...value]
-        activeModal = new Modal(options) // eslint-disable-line no-new
-      }
+    for (var key in triggerMap) {
+      let value = triggerMap[key]
+      options.targetModal = key
+      options.triggers = [...value]
+      activeModal = new Modal(options) // eslint-disable-line no-new
     }
   }
 

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -287,11 +287,13 @@ const MicroModal = (() => {
     if (options.debugMode === true && validateArgs(triggers, triggerMap) === false) return
 
     // For every target modal creates a new instance
-    for (var key in triggerMap) {
-      let value = triggerMap[key]
-      options.targetModal = key
-      options.triggers = [...value]
-      activeModal = new Modal(options) // eslint-disable-line no-new
+    if (triggerMap.length > 0) {
+      for (var key in triggerMap) {
+        let value = triggerMap[key]
+        options.targetModal = key
+        options.triggers = [...value]
+        activeModal = new Modal(options) // eslint-disable-line no-new
+      }
     }
   }
 
@@ -322,7 +324,9 @@ const MicroModal = (() => {
    * @return {void}
    */
   const close = targetModal => {
-    targetModal ? activeModal.closeModalById(targetModal) : activeModal.closeModal()
+    if (activeModal) {
+      targetModal ? activeModal.closeModalById(targetModal) : activeModal.closeModal()
+    }
   }
 
   return { init, show, close }


### PR DESCRIPTION
Hi.

First of all thank you for this great library.

I'm developing Ember addon for your library.

2 things causes trouble.

First, Ember internally changes primitive types which in init function triggerMap is an Array but Ember adds a property named _super and this causes an error. Simply check for length greater than 0 fixes the issue and doesn't change the behaviour.

Second, as you may know we are building 2-way binding for show or close function. Which this is essentially a boolean value. But if the programmer set the value false initially causes error because your library waiting call init or show function first. Simply check for activeModal fixes the issue and also doesn't change the behaviour.

Thank you.