### PR TITLE
Remove Bad Apostrophe

### DIFF
--- a/docs/src/index.html
+++ b/docs/src/index.html
@@ -243,7 +243,7 @@ https://unpkg.com/micromodal/dist/micromodal.min.js
 
         <ul class="ordered lh-copy pl0 mv4">
           <li class="pl4 pv3">
-            This is the outermost container of the modal. It's job is to toggle the display of the modal. It is
+            This is the outermost container of the modal. Its job is to toggle the display of the modal. It is
             important that every modal have a unique <code>id</code>. By default the <code>aria-hidden</code> will be
             <code>true</code>. Micromodal takes care of toggling the value when required.
           </li>


### PR DESCRIPTION
A possessive belonging to an "it" doesn't need an apostrophe. Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!