### PR TITLE
adds event preventdefault and stoppropagation to closemodal

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -94,6 +94,8 @@ const MicroModal = (() => {
       } else {
         modal.classList.remove(this.config.openClass)
       }
+      event.preventDefault()
+      event.stopPropagation()
     }
 
     closeModalById (targetModal) {


### PR DESCRIPTION
so that events are more contained. as requested in #324 this stops the clicks from breaking out and should be a default behavior most likely.