### PR TITLE
fix: programmatically closing multiple modals content issue

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -206,6 +206,7 @@ const MicroModal = (() => {
 
   // Keep a reference to the opened modal
   let activeModal = null
+  const activeModals = {}
 
   /**
    * Generates an associative array of modals and it's
@@ -292,6 +293,7 @@ const MicroModal = (() => {
       options.targetModal = key
       options.triggers = [...value]
       activeModal = new Modal(options) // eslint-disable-line no-new
+      activeModals[key] = activeModal
     }
   }
 
@@ -322,7 +324,7 @@ const MicroModal = (() => {
    * @return {void}
    */
   const close = targetModal => {
-    targetModal ? activeModal.closeModalById(targetModal) : activeModal.closeModal()
+    targetModal ? activeModals[targetModal].closeModalById(targetModal) : activeModals[targetModal].closeModal()
   }
 
   return { init, show, close }


### PR DESCRIPTION
## Context

If using multiple modals and programmatically closing any of them, the last modal will have a content of previously closed modal. See issue https://github.com/ghosh/Micromodal/issues/338

## Fix

On `init` multiple modals and created but only last one is stored in `activeModal` variable. Simple fix is to add an object to keep all instances accessible..