### PR TITLE
Use passive event listener on touchstart

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -116,7 +116,7 @@ const MicroModal = (() => {
     }
 
     addEventListeners () {
-      this.modal.addEventListener('touchstart', this.onClick)
+      this.modal.addEventListener('touchstart', this.onClick, { passive: true })
       this.modal.addEventListener('click', this.onClick)
       document.addEventListener('keydown', this.onKeydown)
     }


### PR DESCRIPTION
Improves scrolling performance, see: https://web.dev/uses-passive-event-listeners/

Closes #374