### PR TITLE
Remove { passive: true } from touchstart listener

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -116,7 +116,7 @@ const MicroModal = (() => {
     }
 
     addEventListeners () {
-      this.modal.addEventListener('touchstart', this.onClick, { passive: true })
+      this.modal.addEventListener('touchstart', this.onClick)
       this.modal.addEventListener('click', this.onClick)
       document.addEventListener('keydown', this.onKeydown)
     }


### PR DESCRIPTION
This was causing an error:

    Unable to preventDefault inside passive event listener invocation.

Essentially reverts https://github.com/ghosh/Micromodal/pull/478.

Related to #475, #477, #479