### PR TITLE
Fix close button target when using SVG as inner content

### DIFF
--- a/docs/src/styles/modal.css
+++ b/docs/src/styles/modal.css
@@ -54,6 +54,7 @@
 .modal__close {
   background: transparent;
   border: 0;
+  pointer-events: all;
 }
 
 .modal__header .modal__close:before { content: "\2715"; }

--- a/tests/assets/modal.css
+++ b/tests/assets/modal.css
@@ -55,6 +55,7 @@
 .modal__close {
   background: transparent;
   border: 0;
+  pointer-events: all;
 }
 
 .modal__header .modal__close:before { content: "\2715"; }


### PR DESCRIPTION
When some SVG tag is added inside the close button tag, the action of closing the modal doesn't work. This PR aims to fix that problem.