### PR TITLE
Fix #505

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -133,10 +133,7 @@ const MicroModal = (() => {
      * @param {*} event Click Event
      */
     onClick (event) {
-      if (
-        event.target.hasAttribute(this.config.closeTrigger) ||
-        event.target.parentNode.hasAttribute(this.config.closeTrigger)
-      ) {
+      if (event.target.hasAttribute(this.config.closeTrigger)) {
         event.preventDefault()
         event.stopPropagation()
         this.closeModal(event)


### PR DESCRIPTION
Don't check parentNode on a click to close the modal as it does wrong behavior.