### PR TITLE
Fixed focus leak in some case with tab key press.

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -189,18 +189,21 @@ const MicroModal = (() => {
         return (node.offsetParent !== null)
       })
 
+      // no focusable nodes left
+      if (focusableNodes.length === 0) return
+
       // if disableFocus is true
       if (!this.modal.contains(document.activeElement)) {
         focusableNodes[0].focus()
       } else {
         const focusedItemIndex = focusableNodes.indexOf(document.activeElement)
 
-        if (event.shiftKey && focusedItemIndex === 0) {
+        if (event.shiftKey && (focusedItemIndex === 0 || focusedItemIndex === -1)) {
           focusableNodes[focusableNodes.length - 1].focus()
           event.preventDefault()
         }
 
-        if (!event.shiftKey && focusableNodes.length > 0 && focusedItemIndex === focusableNodes.length - 1) {
+        if (!event.shiftKey && (focusedItemIndex === focusableNodes.length - 1 || focusedItemIndex === -1)) {
           focusableNodes[0].focus()
           event.preventDefault()
         }


### PR DESCRIPTION
Fixed focus leak in the following cases.

case 1:
Click a node preceding the first focusable.
Then press Shift + Tab.

case 2:
Click a node following the last focusable.
Then press Tab.