### PR TITLE
fixes #187

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -279,13 +279,18 @@ const MicroModal = (() => {
   }
 
   /**
+   * Store initialization options at module level.
+   */
+  let options = {}
+
+  /**
    * Binds click handlers to all modal triggers
    * @param  {object} config [description]
    * @return void
    */
   const init = config => {
     // Create an config object with default openTrigger
-    const options = Object.assign({}, { openTrigger: 'data-micromodal-trigger' }, config)
+    options = Object.assign({}, { openTrigger: 'data-micromodal-trigger' }, config)
 
     // Collects all the nodes with the trigger
     const triggers = [...document.querySelectorAll(`[${ options.openTrigger }]`)]
@@ -312,17 +317,17 @@ const MicroModal = (() => {
    * @return {void}
    */
   const show = (targetModal, config) => {
-    const options = config || {}
-    options.targetModal = targetModal
+    const showOptions = config || options
+    showOptions.targetModal = targetModal
 
     // Checks if modals and triggers exist in dom
-    if (options.debugMode === true && validateModalPresence(targetModal) === false) return
+    if (showOptions.debugMode === true && validateModalPresence(targetModal) === false) return
 
     // clear events in case previous modal wasn't closed
     if (activeModal) activeModal.removeEventListeners()
 
     // stores reference to active modal
-    activeModal = new Modal(options) // eslint-disable-line no-new
+    activeModal = new Modal(showOptions) // eslint-disable-line no-new
     activeModal.showModal()
   }
 


### PR DESCRIPTION
Store the options at a module level so we can initialise once:

```
MicroModal.init({
    onShow: modal => console.info(`${modal.id} is shown`),
    onClose: modal => console.info(`${modal.id} is hidden`), 
    awaitCloseAnimation: true,
    awaitOpenAnimation: true
});
```

And share them with `.show()` so we can still use this simple method:
`MicroModal.show('RequestAQuote');`