### PR TITLE
activeElement Visibility Fallback

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -80,8 +80,10 @@ const MicroModal = (() => {
       this.modal.setAttribute('aria-hidden', 'true')
       this.removeEventListeners()
       this.scrollBehaviour('enable')
-      if (this.activeElement && this.activeElement.focus) {
+      if (this.activeElement && this.activeElement.focus && this.activeElement.checkVisibility()) {
         this.activeElement.focus()
+      } else {
+        document.activeElement.blur();
       }
       this.config.onClose(this.modal, this.activeElement, event)
 


### PR DESCRIPTION
### Overview

Updates `closeModal` logic to check if reference to `this.activeElement` is visible before attempting to focus the element. Falls back to blurring current `document.activeElement` (buttons within modal) to prevent aria-hidden warnings when modal closes.

### Motivation

Chrome now displays a warning in the console when a descendant of an element with an `aria-hidden` attribute retains focus.

### Problem Scenario

1. MicroModal is opened via a dropdown menu item that closes (parent is hidden) when the modal opens. 
2. MicroModal tracks the now hidden button as `this.activeElement`. 
3. When the modal closes, it attempts to call `.focus()` on that hidden element to restore focus - which fails and leaves the focus on the button within the modal.
4. Upon closing, Chrome displays a warning because the parent element's `aria-hidden` property is updated but the focus on the descendant button is retained.